### PR TITLE
Add CSRF security token to TOTP token form

### DIFF
--- a/code/LoginForm.php
+++ b/code/LoginForm.php
@@ -85,9 +85,11 @@ class LoginForm extends \MemberLoginForm
         if ($field) {
             return parent::Fields();
         }
+        $security_token = $this->getSecurityToken();
         $fields = \FieldList::create(
             \TextField::create('TOTP', 'Security Token'),
-            \HiddenField::create('BackURL', null, Session::get('BackURL'))
+            \HiddenField::create('BackURL', null, Session::get('BackURL')),
+            \HiddenField::create($security_token->getName(), null, $security_token->getSecurityID())
         );
         foreach ($this->getExtraFields() as $field) {
             if (!$fields->fieldByName($field->getName())) {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 	"require": {
 		"rych/otp": "1.1.*",
 		"endroid/qrcode": "1.3.*",
-		"silverstripe/framework": "~3.1"
+		"silverstripe/framework": "^3.3.2"
 	},
 	"conflict": {
 		"91carriage/2fa": "*"


### PR DESCRIPTION
- This enables the module to work with SilverStripe 3.3.2+.
- Require SilverStripe framework 3.3.2
  
  This is the first version of the framework that uses a CSRF security
  token on login forms.
