### PR TITLE
Change Member.php’s namespace to fix conflicting namespace bug

### DIFF
--- a/_config/2fa.yml
+++ b/_config/2fa.yml
@@ -3,7 +3,7 @@ Name: 2fa
 ---
 Member:
   extensions:
-    - '_2fa\Member'
+    - '_2fa\Extensions\Member'
 Injector:
   MemberLoginForm:
     class: '_2fa\LoginForm'

--- a/code/extension/Member.php
+++ b/code/extension/Member.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace _2fa;
+namespace _2fa\Extensions;
 
 use Rych\OTP\TOTP;
 use Rych\OTP\Seed;

--- a/docs/en/configuration.md
+++ b/docs/en/configuration.md
@@ -4,7 +4,7 @@ All configuration is done through the [Configuration API](http://doc.silverstrip
 
 ## Options
 
- * `_2fa\Member.totp_window` -- The number of tokens in the window users
+ * `_2fa\Extensions\Member.totp_window` -- The number of tokens in the window users
  have to get a correct token. If this is 0, then only the current token is
  accepted. **Note:** this is the total size of the window, not the size either
  side of the current token. For example, the default value of 2 allows for users
@@ -15,7 +15,7 @@ All configuration is done through the [Configuration API](http://doc.silverstrip
 
 ## Example configuration
 ```yaml
- _2fa\Member:
+ _2fa\Extensions\Member:
    totp_window: 2
 ```
 


### PR DESCRIPTION
This fixes the error:

```
PHP Fatal error:  Cannot use Member as Member because the name is already in use in /home/project_folder/public_html/twofactorauth/code/form/ChangePasswordForm.php on line 5
```

It came up when a user tried to change his password and the Security/changepassword site gave a 500 server error.

The culprit was the conflicting Member extension that conflicted with Silverstripe's Member class. By changing the namespace from `_2fa` to `_2fa\Extensions`the bug was fixed.