### PR TITLE
Generate initial token if configured to not regenerate on Has2FA change

### DIFF
--- a/code/extension/Member.php
+++ b/code/extension/Member.php
@@ -26,6 +26,8 @@ class Member extends \DataExtension
 
     private static $admins_can_disable = false;
 
+    private static $regenerate_on_activation = true;
+
     private static $totp_window = 2;
 
     public function validateTOTP($token)
@@ -88,6 +90,12 @@ class Member extends \DataExtension
      */
     public function updateCMSFields(\FieldList $fields)
     {
+        // Generate default token (allows scanning the QR at the moment of activation and (optionally) validate before activating 2FA)
+        if(!$this->owner->TOTPToken && !\Config::inst()->get(__CLASS__, 'regenerate_on_activation')) {
+            $this->generateTOTPToken();
+            $this->owner->write();
+        }
+        
         $fields->removeByName('TOTPToken');
         $fields->removeByName('BackupTokens');
         if (!(\Config::inst()->get(__CLASS__, 'admins_can_disable') && $this->owner->Has2FA && \Permission::check('ADMIN'))) {
@@ -119,7 +127,7 @@ class Member extends \DataExtension
 
     public function onBeforeWrite()
     {
-        if ($this->owner->isChanged('Has2FA', 2) && $this->owner->Has2FA) {
+        if ($this->owner->isChanged('Has2FA', 2) && $this->owner->Has2FA && \Config::inst()->get(__CLASS__, 'regenerate_on_activation')) {
             $this->generateTOTPToken();
         }
     }


### PR DESCRIPTION
Not too sure about the point where this should happen; updateCMSFields may not get called based upon implementation. populateDefaults() only gets called for new records (and would need a write action as well for the TOTP token to persist). requireDefaultRecords() would get called upon build, but not for newly created members. Hence the decision to implement on updateCMSFields. FIX: #13